### PR TITLE
fix wrong URL to Japanese README-jp.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[日本語版はこちらにあります](https://github.com/inter-mediator/IMApp_Trial/blob/master/README-ja.md)
+[日本語版はこちらにあります](https://github.com/inter-mediator/IMApp_Trial/blob/master/README-jp.md)
 
 
 # IMApp_Trial


### PR DESCRIPTION
日本語README-jp.md へのリンクが間違っていました。直しました