### PR TITLE
added my.conf and fix docker-compose.yaml for fixing Client characterset:latin1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,9 @@ services:
       - type: bind
         source: ./lib/docker/mysql/db
         target: /var/lib/mysql
+      - db:/var/lib/mysql
+      # ~~~~~~~ 以下のコードを追記 ~~~~~~~~~~~~
+      - ./my.cnf:/etc/mysql/conf.d/my.cnf
     environment:
       MYSQL_DATABASE: test_db
       MYSQL_ROOT_PASSWORD: im4135dev
@@ -34,6 +37,8 @@ services:
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     ports:
       - 127.0.0.1:13306:3306
+volumes:
+  db:
 #  mailhog:
 #    image: mailhog/mailhog
 #    ports:

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,9 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+explicit-defaults-for-timestamp=1
+general-log=1
+general-log-file=/var/log/mysql/mysqld.log
+
+[client]
+default-character-set=utf8mb4


### PR DESCRIPTION
Fixed garbled Japanese characters when displaying MySQL data in the docker container using the terminal.